### PR TITLE
Use bitpoke/wordpress-site helm chart 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/application/c
 For convenience we collect all necessary CRDs in one place so you can simply install them.
 
 ```
-export STACK_VERSION=0.12.0
+export STACK_VERSION=0.12.1
 kubectl apply -f https://raw.githubusercontent.com/bitpoke/stack/v${STACK_VERSION}/deploy/00-crds.yaml
 ```
 
@@ -84,7 +84,7 @@ have some room for deploying a site. For testing out and playground `e1-small`
 should suffice.
 
 ```bash
-export STACK_VERSION=0.12.0
+export STACK_VERSION=0.12.1
 helm install \
     stack bitpoke/stack \
     --create-namespace \    
@@ -99,7 +99,7 @@ Ensure a larger Minikube with eg, `minikube start --cpus 4 --memory 8192` to
 provide a working local environment.
 
 ```
-export STACK_VERSION=0.12.0
+export STACK_VERSION=0.12.1
 helm install \
     stack bitpoke/stack \
     --create-namespace \
@@ -112,7 +112,7 @@ helm install \
 
 ### Deploying a site
 ```
-export STACK_VERSION=0.12.0
+export STACK_VERSION=0.12.1
 helm install \
     mysite bitpoke/wordpress-site \
     --version v${STACK_VERSION} \


### PR DESCRIPTION
Follow-up on https://github.com/bitpoke/stack/issues/131
Use the  `bitpoke/wordpress-site` helm chart which is published in version `0.12.1` only.

```shell
$ helm install \
    mysite bitpoke/wordpress-site \
    --version v0.12.0 \
    --set 'site.domains[0]=www.example.com'
Error: INSTALLATION FAILED: failed to download "bitpoke/wordpress-site" at version "v0.12.0"


$ helm install \
    mysite bitpoke/wordpress-site \
    --version v0.12.1 \
    --set 'site.domains[0]=www.example.com'
NAME: mysite
LAST DEPLOYED: Tue Feb  1 22:24:10 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Change your DNS records to point www.example.com at the ingress
controller endpoints

2. Visit the site at:
    http://www.example.com

3. That's it!
```
